### PR TITLE
add better ci integration and make file for dev

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,3 +24,8 @@ indent_size = 4
 ; YAML
 [*.{yaml,yml}]
 indent_size = 2
+
+; Makefile
+[Makefile]
+indent_style = tab
+indent_size = 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ go:
 
 script: 
 # No tests yet, so we'll do a trial build
- - go build .
+ - make ci
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,24 @@
 
+dev:
+	go fmt ./...
+	go vet ./...
+	go test ./...
+
 install:
 	go fmt ./...
 	go vet ./...
 	go test ./...
 	go install .
+
+lint:
+	@if gofmt -l . | egrep -v ^vendor/ | grep .go; then \
+	  echo "^- Repo contains improperly formatted go files; run make dev" && exit 1; \
+	  else echo "All .go files formatted correctly"; fi
+	go vet *.go
+
+ci: lint
+	go get 
+	go test .
 
 build:
 	GOOS=darwin GOARCH=amd64 go build -o purr_darwin_amd64 .

--- a/main.go
+++ b/main.go
@@ -5,16 +5,17 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/bluele/slack"
 	"github.com/dustin/go-humanize"
 	"github.com/google/go-github/github"
 	"github.com/xanzy/go-gitlab"
 	"golang.org/x/oauth2"
-	"os"
-	"strings"
-	"sync"
-	"time"
 )
 
 const (


### PR DESCRIPTION
Use the makefile for ci runs

will check that tests runs, that code is formatted properly and go vet doesn't complain.

https://travis-ci.org/stojg/purr/jobs/230171052